### PR TITLE
gconf: Move getting proxy settings to misc.h/misc.c only

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -37,6 +37,19 @@ gfloat gconf_get_float(const char *key, gfloat default_value);
 
 char *url_encode(const char *str);
 
+struct proxy_config {
+    // Host is NULL if no proxy should be used
+    gchar *host;
+    int port;
+
+    // Username is NULL if no auth should be used
+    gchar *username;
+    gchar *password;
+};
+
+struct proxy_config *proxy_config_get();
+void proxy_config_free(struct proxy_config *config);
+
 #ifdef WITH_GTK
 #include <gtk/gtk.h>
 GtkWidget *notebook_new(void);


### PR DESCRIPTION
This moves all usage of GConf to misc.c, so it's easier to refactor
later. Also, depending on the OS, the proxy settings might be stored
in another place, so this makes it easier to support different OSes.

Please test if this works for all the platforms that are supported.
