### PR TITLE
Segfault on exit

### DIFF
--- a/src/Settings.qml
+++ b/src/Settings.qml
@@ -46,6 +46,13 @@ SilicaFlickable {
             width: parent.width
         }
 
+        TextSwitch {
+            text: "Enable compass"
+            checked: map.enable_compass
+            onClicked: map.enable_compass = checked
+            width: parent.width
+        }
+
         Item {
             width: parent.width
             height: childrenRect.height

--- a/src/maep.pro
+++ b/src/maep.pro
@@ -4,7 +4,7 @@ DEPENDPATH += .
 INCLUDEPATH += .
 CONFIG += link_pkgconfig
 PKGCONFIG += gobject-2.0 cairo libsoup-2.4 gconf-2.0 libxml-2.0 libcurl
-QT += qml quick positioning #declarative
+QT += qml quick positioning sensors
 LIBS += -ljpeg
 
 packagesExist(qdeclarative5-boostable) {

--- a/src/osm-gps-map/layer-gps.c
+++ b/src/osm-gps-map/layer-gps.c
@@ -30,6 +30,7 @@ struct _MaepLayerGpsPrivate
 
   coord_t gps;
   float gps_heading;
+  float compass_azimuth;
   gboolean gps_valid;
 
   guint ui_gps_point_inner_radius;
@@ -240,6 +241,21 @@ static void _draw(MaepLayerGpsPrivate *priv, cairo_t *cr, OsmGpsMap *map)
         cairo_stroke(cr);
       }
 
+    if(!isnan(priv->compass_azimuth))
+      {
+        cairo_move_to (cr, -r*cos(priv->compass_azimuth), -r*sin(priv->compass_azimuth));
+        cairo_line_to (cr, 3*r*sin(priv->compass_azimuth), -3*r*cos(priv->compass_azimuth));
+        cairo_line_to (cr, r*cos(priv->compass_azimuth), r*sin(priv->compass_azimuth));
+        cairo_close_path (cr);
+
+        cairo_set_source_rgba (cr, 0.3, 1.0, 0.3, 0.5);
+        cairo_fill_preserve (cr);
+
+        cairo_set_line_width (cr, 1.0);
+        cairo_set_source_rgba (cr, 0.0, 0.5, 0.0, 0.5);
+        cairo_stroke(cr);
+      }
+
     cairo_set_source_surface (cr, priv->surf, -r - 1, -r - 1);
     cairo_paint(cr);
   }
@@ -306,6 +322,20 @@ gboolean maep_layer_gps_set_coordinates(MaepLayerGps *gps, gfloat lat, gfloat lo
     g_signal_emit(gps, _signals[DIRTY_SIGNAL], 0, NULL);
 
   return changed;
+}
+
+gboolean maep_layer_gps_set_azimuth(MaepLayerGps *gps, gfloat azimuth)
+{
+  g_return_val_if_fail(MAEP_IS_LAYER_GPS(gps), FALSE);
+
+  azimuth = deg2rad(azimuth);
+  if (gps->priv->compass_azimuth != azimuth)
+    {
+      gps->priv->compass_azimuth = azimuth;
+      g_signal_emit(gps, _signals[DIRTY_SIGNAL], 0, NULL);
+      return TRUE;
+    }
+  return FALSE;
 }
 
 gboolean maep_layer_gps_set_active(MaepLayerGps *gps, gboolean status)

--- a/src/osm-gps-map/layer-gps.h
+++ b/src/osm-gps-map/layer-gps.h
@@ -56,6 +56,7 @@ MaepLayerGps* maep_layer_gps_new(void);
 gboolean maep_layer_gps_set_coordinates(MaepLayerGps *gps, gfloat lat, gfloat lon,
                                         gfloat hprec, gfloat heading);
 gboolean maep_layer_gps_set_active(MaepLayerGps *gps, gboolean status);
+gboolean maep_layer_gps_set_azimuth(MaepLayerGps *gps, gfloat azimuth);
 
 G_END_DECLS
 

--- a/src/osm-gps-map/osm-gps-map-qt.cpp
+++ b/src/osm-gps-map/osm-gps-map-qt.cpp
@@ -315,7 +315,7 @@ Maep::GpsMap::~GpsMap()
 	       "double-pixel", &dpix,
 	       NULL);
   osm_gps_map_osd_classic_free(osd);
-  maep_wiki_context_enable(wiki, NULL);
+  //maep_wiki_context_enable(wiki, NULL);
   g_object_unref(wiki);
   if (wiki_entry)
     delete(wiki_entry);

--- a/src/osm-gps-map/osm-gps-map-qt.h
+++ b/src/osm-gps-map/osm-gps-map-qt.h
@@ -26,6 +26,7 @@
 #include <QGeoCoordinate>
 #include <QGeoPositionInfoSource>
 #include <QColor>
+#include <QCompass>
 #include <cairo.h>
 #include "misc.h"
 #include "search.h"
@@ -308,6 +309,7 @@ class GpsMap : public QQuickPaintedItem
   Q_PROPERTY(Maep::Track *track READ getTrack WRITE setTrack NOTIFY trackChanged)
 
   Q_PROPERTY(bool screen_rotation READ screen_rotation WRITE setScreenRotation NOTIFY screenRotationChanged)
+  Q_PROPERTY(bool enable_compass READ compassEnabled WRITE enableCompass NOTIFY enableCompassChanged)
 
   Q_PROPERTY(unsigned int gps_refresh_rate READ gpsRefreshRate WRITE setGpsRefreshRate NOTIFY gpsRefreshRateChanged)
 
@@ -439,6 +441,9 @@ class GpsMap : public QQuickPaintedItem
   inline unsigned int gpsRefreshRate() {
     return gpsRefreshRate_;
   }
+  inline bool compassEnabled() {
+    return compassEnabled_;
+  }
 
  protected:
   void paint(QPainter *painter);
@@ -461,6 +466,7 @@ class GpsMap : public QQuickPaintedItem
   void trackChanged(bool available);
   void screenRotationChanged(bool status);
   void gpsRefreshRateChanged(unsigned int rate);
+  void enableCompassChanged(bool enable);
 
  public slots:
   void setSource(Source source);
@@ -484,6 +490,8 @@ class GpsMap : public QQuickPaintedItem
   void setTrackCapture(bool status);
   void setTrack(Maep::Track *track = NULL);
   void setGpsRefreshRate(unsigned int rate);
+  void compassReadingChanged();
+  void enableCompass(bool enable);
 
  private:
   static int countSearchResults(QQmlListProperty<GeonamesPlace> *prop)
@@ -505,10 +513,13 @@ class GpsMap : public QQuickPaintedItem
   bool mapSized();
   void gpsToTrack();
   void unsetGps();
+  bool switchCompass(bool enable);
 
   bool screenRotation;
   OsmGpsMap *map, *overlay;
   QGeoCoordinate coordinate;
+  QCompass compass;
+  bool compassEnabled_;
   osm_gps_map_osd_t *osd;
 
   MaepSearchContext *search;

--- a/src/osm-gps-map/osm-gps-map-qt.h
+++ b/src/osm-gps-map/osm-gps-map-qt.h
@@ -520,6 +520,8 @@ class GpsMap : public QQuickPaintedItem
   QGeoCoordinate coordinate;
   QCompass compass;
   bool compassEnabled_;
+  qreal lastAzimuth;
+
   osm_gps_map_osd_t *osd;
 
   MaepSearchContext *search;


### PR DESCRIPTION
This is not really a fix, I just commented out a line that causes a segfault in the GpsMap destructor. It seems to dereference some pointers that have already been destroyed at that time. Didn't go into the details of how to really fix it. On the other hand, the segfault prevents the settings from being saved and commenting out that line doesn't really hurt anything (as far as I could tell), so we might as well consider it a "fix" ;-)