### PR TITLE
Make compass reference frame switchable

### DIFF
--- a/src/Settings.qml
+++ b/src/Settings.qml
@@ -37,7 +37,7 @@ SilicaFlickable {
 
         TextSwitch {
 	    text: "Draw map double pixel"
-            description: "The tiles of the zoom level above are" +
+            description: "The tiles of the zoom level above are " +
             "used instead of the normal ones. The rendering appears as if zoomed."
 	    checked: map.double_pixel
             automaticCheck: false
@@ -46,13 +46,21 @@ SilicaFlickable {
             width: parent.width
         }
 
-        TextSwitch {
-            text: "Enable compass"
-            checked: map.enable_compass
-            description: "Display a compass arrow under the GPS point" +
-            " (green points in the north direction)."
-            onClicked: map.enable_compass = checked
-            width: parent.width
+        ComboBox {
+            label: "Compass mode"
+            width: page.width
+            description: "Either point towards physical north pole, or show " +
+                         "device orientation relative to map. When switched " +
+                         "off, the sensor is completely disabled."
+
+            currentIndex: map.compass_mode
+            onCurrentIndexChanged: map.compass_mode = currentIndex
+
+            menu: ContextMenu {
+                MenuItem { text: "Off" }
+                MenuItem { text: "Point north" }
+                MenuItem { text: "Device orientation" }
+            }
         }
 
         Item {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,8 @@ QQuickView *Maep::createView(const QString &file)
             QString basePath = QCoreApplication::applicationFilePath();
             basePath.chop(basePath.length() -  basePath.indexOf("/", 9)); // first index after /opt/sdk/
             view->engine()->addImportPath(basePath + path);
+            if (!path.endsWith("/"))
+              path += "/";
             view->setSource(QUrl::fromLocalFile(basePath + path + file));
           }
         else

--- a/src/misc.c
+++ b/src/misc.c
@@ -51,6 +51,19 @@ static DConfClient* dconf_client_get_default()
   return dconfClient;
 }
 
+void gconf_unset_key(const char *m_key) {
+  DConfClient *client = dconf_client_get_default();
+  char *key = g_strdup_printf(GCONF_PATH, m_key);
+  GError *error = NULL;
+
+  dconf_client_write_sync(client, key, NULL, NULL, NULL, &error);
+  g_free(key);
+  if (error) {
+    g_warning("%s", error->message);
+    g_error_free(error);
+  }
+}
+
 void gconf_set_string(const char *m_key, const char *str) {
   /* GConfClient *client = gconf_client_get_default(); */
   DConfClient *client = dconf_client_get_default();

--- a/src/misc.h
+++ b/src/misc.h
@@ -26,6 +26,7 @@ G_BEGIN_DECLS
 
 char *find_file(char *name);
 
+void gconf_unset_key(const char *key);
 void gconf_set_string(const char *key, const char *str);
 char *gconf_get_string(const char *key);
 void gconf_set_bool(const char *key, gboolean value);

--- a/src/osm-gps-map/layer-gps.h
+++ b/src/osm-gps-map/layer-gps.h
@@ -34,6 +34,12 @@ G_BEGIN_DECLS
 #define MAEP_IS_LAYER_GPS_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE(klass, MAEP_TYPE_LAYER_GPS))
 #define MAEP_LAYER_GPS_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS(obj, MAEP_TYPE_LAYER_GPS, MaepLayerGpsClass))
 
+#define MAEP_COMPASS_MODES \
+  COMPASS_MODE_OFF = 0, \
+  COMPASS_MODE_NORTH, \
+  COMPASS_MODE_DEVICE, \
+  COMPASS_N_MODES
+
 typedef struct _MaepLayerGps        MaepLayerGps;
 typedef struct _MaepLayerGpsPrivate MaepLayerGpsPrivate;
 typedef struct _MaepLayerGpsClass   MaepLayerGpsClass;
@@ -50,6 +56,10 @@ struct _MaepLayerGpsClass
   GObjectClass parent;
 };
 
+typedef enum {
+    MAEP_COMPASS_MODES
+} MaepLayerCompassMode;
+
 GType maep_layer_gps_get_type(void);
 
 MaepLayerGps* maep_layer_gps_new(void);
@@ -57,6 +67,7 @@ gboolean maep_layer_gps_set_coordinates(MaepLayerGps *gps, gfloat lat, gfloat lo
                                         gfloat hprec, gfloat heading);
 gboolean maep_layer_gps_set_active(MaepLayerGps *gps, gboolean status);
 gboolean maep_layer_gps_set_azimuth(MaepLayerGps *gps, gfloat azimuth);
+gboolean maep_layer_gps_set_compass_mode(MaepLayerGps *gps, MaepLayerCompassMode mode);
 
 G_END_DECLS
 

--- a/src/osm-gps-map/osm-gps-map-qt.h
+++ b/src/osm-gps-map/osm-gps-map-qt.h
@@ -291,6 +291,7 @@ class GpsMap : public QQuickPaintedItem
   Q_OBJECT
 
   Q_ENUMS(Source)
+  Q_ENUMS(CompassMode)
 
   Q_PROPERTY(Source source READ source WRITE setSource NOTIFY sourceChanged)
   Q_PROPERTY(Source overlaySource READ overlaySource WRITE setOverlaySource NOTIFY overlaySourceChanged)
@@ -312,7 +313,7 @@ class GpsMap : public QQuickPaintedItem
   Q_PROPERTY(QColor trackColor READ getTrackColor WRITE setTrackColor NOTIFY trackColorChanged)
 
   Q_PROPERTY(bool screen_rotation READ screen_rotation WRITE setScreenRotation NOTIFY screenRotationChanged)
-  Q_PROPERTY(bool enable_compass READ compassEnabled WRITE enableCompass NOTIFY enableCompassChanged)
+  Q_PROPERTY(CompassMode compass_mode READ compassMode WRITE setCompassMode NOTIFY compassModeChanged)
 
   Q_PROPERTY(unsigned int gps_refresh_rate READ gpsRefreshRate WRITE setGpsRefreshRate NOTIFY gpsRefreshRateChanged)
 
@@ -348,6 +349,10 @@ class GpsMap : public QQuickPaintedItem
     SOURCE_MML_TAUSTAKARTTA,
 
     SOURCE_LAST};
+
+  enum CompassMode {
+    MAEP_COMPASS_MODES
+  };
 
   GpsMap(QQuickItem *parent = 0);
   ~GpsMap();
@@ -449,8 +454,8 @@ class GpsMap : public QQuickPaintedItem
   inline unsigned int gpsRefreshRate() {
     return gpsRefreshRate_;
   }
-  inline bool compassEnabled() {
-    return compassEnabled_;
+  inline CompassMode compassMode() {
+    return compassMode_;
   }
 
  protected:
@@ -476,7 +481,7 @@ class GpsMap : public QQuickPaintedItem
   void trackColorChanged();
   void screenRotationChanged(bool status);
   void gpsRefreshRateChanged(unsigned int rate);
-  void enableCompassChanged(bool enable);
+  void compassModeChanged(CompassMode mode);
 
  public slots:
   void setSource(Source source);
@@ -503,7 +508,7 @@ class GpsMap : public QQuickPaintedItem
   void setTrackColor(const QColor &value);
   void setGpsRefreshRate(unsigned int rate);
   void compassReadingChanged();
-  void enableCompass(bool enable);
+  void setCompassMode(CompassMode mode);
 
  private:
   static int countSearchResults(QQmlListProperty<GeonamesPlace> *prop)
@@ -530,7 +535,7 @@ class GpsMap : public QQuickPaintedItem
   OsmGpsMap *map, *overlay;
   QGeoCoordinate coordinate;
   QCompass compass;
-  bool compassEnabled_;
+  CompassMode compassMode_;
   qreal lastAzimuth;
 
   osm_gps_map_osd_t *osd;


### PR DESCRIPTION
I find it impractical to have the compass point to the north pole. Instead I want it to show the device's orientation relative to the map I'm seeing. Since modes of orientation are diverse, I think it's best to support both options and let the user choose what works most intuitively for them.