### PR TITLE
save track h_acc via g_ascii_dtostr to avoid , as decimal seperator

### DIFF
--- a/src/track.c
+++ b/src/track.c
@@ -720,8 +720,8 @@ static void track_save_point(track_point_t *point, xmlNodePtr node) {
       xmlNewChild(node, NULL, BAD_CAST "extensions", NULL);
 
     if(point->h_acc != G_MAXFLOAT) {
-      char *lstr = g_strdup_printf("%g", point->h_acc);
-      xmlNewTextChild(ext, NULL, BAD_CAST "h_acc", BAD_CAST lstr);
+      g_ascii_dtostr(str, sizeof(str), point->h_acc);
+      xmlNewTextChild(ext, NULL, BAD_CAST "h_acc", BAD_CAST str);
       g_free(lstr);
     }
 


### PR DESCRIPTION
On my device which has a de_DE locale the track files have invalid xml for h_acc like this fake sample:
```
<trkpt lat="99.9999999" lon="99.9999999">
        <ele>999.99</ele>
                <extensions>
                        <h_acc>99,999</h_acc>
                </extensions>
        <time>2019-06-16T00:00:00</time>
</trkpt>
```

which is due to the use of g_strdup_printf in the track saving code
https://github.com/dcaliste/maep-qt/blob/84f440c3b817f27762ab8938453de46b438e51a3/src/track.c#L722-L726
Interestingly the code responsible of loading track points is already using the right g_ascii_strtod call
https://github.com/dcaliste/maep-qt/blob/84f440c3b817f27762ab8938453de46b438e51a3/src/track.c#L396-L401